### PR TITLE
let constructor can be BigNumber or BN

### DIFF
--- a/chai-bignumber.js
+++ b/chai-bignumber.js
@@ -15,7 +15,7 @@ module.exports = function (BigNumber) {
     var isBigNumber = function (object) {
       return object.isBigNumber ||
         object instanceof BigNumber ||
-        (object.constructor && object.constructor.name === 'BigNumber');
+        (object.constructor && (object.constructor.name === 'BN' || object.constructor.name === 'BigNumber'));
     };
 
     var convert = function (value, dp, rm) {


### PR DESCRIPTION
Some nodejs , BigNumber will be BN insetad of BigNumber.
That caused `isBigNumber` always false.