### PR TITLE
Add greaterThanOrEqual and lessThanOrEqual aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ builtin assertions if the `bignumber` property is explicitly set as part of
 the assertion chain:
 - equal/equals/eq
 - above/gt/greaterThan
-- least/gte
+- least/gte/greaterThanOrEqual
 - below/lt/lessThan
-- most/lte
+- most/lte/lessThanOrEqual
 
 The above methods have the following signature: `(value, dp, rm)`.
 Where `dp` is an optional argument which specifies the number of decimal places

--- a/chai-bignumber.js
+++ b/chai-bignumber.js
@@ -80,7 +80,7 @@ module.exports = function (BigNumber) {
     });
 
     // BigNumber.isGreaterThanOrEqualTo
-    overwriteMethods(['least', 'gte'], function (expected, actual) {
+    overwriteMethods(['least', 'gte', 'greaterThanOrEqual'], function (expected, actual) {
       this.assert(
         isGreaterThanOrEqualTo.bind(actual)(expected),
         'expected #{act} to be greater than or equal to #{exp}',
@@ -102,7 +102,7 @@ module.exports = function (BigNumber) {
     });
 
     // BigNumber.isLessThanOrEqualTo
-    overwriteMethods(['most', 'lte'], function (expected, actual) {
+    overwriteMethods(['most', 'lte', 'lessThanOrEqual'], function (expected, actual) {
       this.assert(
         isLessThanOrEqualTo.bind(actual)(expected),
         'expected #{act} to be less than or equal to #{exp}',

--- a/test/chai-bignumber.test.js
+++ b/test/chai-bignumber.test.js
@@ -190,7 +190,7 @@ describe('chai-bignumber', function () {
     });
   });
 
-  describe('least/gte', function () {
+  describe('least/gte/greaterThanOrEqual', function () {
     it('should be greater than or equal to', function () {
       var tests = [
         [15, 10],
@@ -375,7 +375,7 @@ describe('chai-bignumber', function () {
     });
   });
 
-  describe('most/lte', function () {
+  describe('most/lte/lessThanOrEqual', function () {
     it('should be less than or equal to', function () {
       var tests = [
         [10, 10],


### PR DESCRIPTION
There are aliases in chai for [greaterThanOrEqual](https://www.chaijs.com/api/bdd/#leastn-msg) and [lessThanOrEqual](https://www.chaijs.com/api/bdd/#mostn-msg), but no corresponding aliases in chai-bignumber. I noticed because I got a weird test failure when switching some objects over to BigNumber: something like a type mismatch where it expected a number or a Date.